### PR TITLE
Implement async support for the `async` feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,46 @@ for event in subscription.iter() {
 }
 ```
 
+## Async Event Listening
+
+Enable the `async` feature to get `AsyncEventSubscription` and
+`flush_led_colors_async()`:
+
+```toml
+[dependencies]
+cue-sdk = { version = "0.1", features = ["async"] }
+```
+
+```rust
+use std::time::Duration;
+use cue_sdk::event::Event;
+
+#[tokio::main]
+async fn main() {
+    let session = cue_sdk::connect().expect("connect failed");
+    session.wait_for_connection(Duration::from_secs(5)).expect("timeout");
+
+    let mut subscription = session.subscribe_for_events_async().expect("subscribe");
+    while let Some(event) = subscription.recv().await {
+        match event {
+            Event::DeviceConnectionChanged { device_id, is_connected } => {
+                println!("Device {} {}", device_id,
+                    if is_connected { "connected" } else { "disconnected" });
+            }
+            Event::KeyEvent { device_id, key_id, is_pressed } => {
+                println!("Key {:?} {} on {}", key_id,
+                    if is_pressed { "pressed" } else { "released" }, device_id);
+            }
+        }
+    }
+}
+```
+
 ## Features
 
 | Feature | Description |
 |---------|-------------|
-| `async` | Adds optional `tokio` dependency for async event support |
+| `async` | Adds `AsyncEventSubscription` and `flush_led_colors_async()` via optional `tokio` dependency |
 
 ## Examples
 
@@ -99,6 +134,7 @@ cargo run --example connect        # Print SDK version info
 cargo run --example devices        # List connected devices
 cargo run --example set_colors     # Set all keyboard LEDs to red
 cargo run --example events         # Listen for device/key events
+cargo run --example events_async --features async  # Async event listener
 ```
 
 ## Architecture

--- a/examples/events_async.rs
+++ b/examples/events_async.rs
@@ -1,0 +1,41 @@
+use std::time::Duration;
+
+use cue_sdk::event::Event;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let session = cue_sdk::connect().expect("failed to connect");
+    let _details = session
+        .wait_for_connection(Duration::from_secs(5))
+        .expect("timeout waiting for iCUE");
+
+    let mut subscription = session
+        .subscribe_for_events_async()
+        .expect("failed to subscribe");
+
+    println!("Listening for events (async)... Press Ctrl+C to exit.");
+
+    while let Some(event) = subscription.recv().await {
+        match event {
+            Event::DeviceConnectionChanged {
+                device_id,
+                is_connected,
+            } => {
+                let action = if is_connected {
+                    "connected"
+                } else {
+                    "disconnected"
+                };
+                println!("Device {} {}", device_id, action);
+            }
+            Event::KeyEvent {
+                device_id,
+                key_id,
+                is_pressed,
+            } => {
+                let action = if is_pressed { "pressed" } else { "released" };
+                println!("Key {:?} {} on device {}", key_id, action, device_id);
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@ pub mod session;
 
 pub use device::{DeviceId, DeviceInfo, DeviceType};
 pub use error::{Result, SdkError};
+#[cfg(feature = "async")]
+pub use event::AsyncEventSubscription;
 pub use event::{Event, EventSubscription, MacroKeyId};
 pub use led::{LedColor, LedPosition};
 pub use property::{PropertyId, PropertyValue};


### PR DESCRIPTION
## Summary

- Add `AsyncEventSubscription` with async `recv()` using tokio unbounded channels, mirroring the existing sync `EventSubscription` pattern
- Add `Session::flush_led_colors_async()` as an async counterpart to the blocking `flush_led_colors()`
- Add `events_async` example and update README with async usage documentation

## Design

The tokio `UnboundedSender::send(&self, T)` is **synchronous**, so it works safely inside `extern "C"` callback trampolines without needing a tokio runtime context. Only the receiver side (`.recv().await`) is async. This lets us reuse the existing `Pin<Box<Sender>>` + trampoline pattern with zero changes to the callback safety model.

All new code is gated behind `#[cfg(feature = "async")]` — the sync path is completely unchanged.

## Test plan

- [x] `cargo check` — sync path unchanged
- [x] `cargo check --features async` — async path compiles
- [x] `cargo clippy -- -D warnings` — no warnings (sync)
- [x] `cargo clippy --all-targets --features async -- -D warnings` — no warnings (async + examples)
- [x] `cargo fmt --check` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)