### PR TITLE
Fix macOS SIGBUS on reconnect and serialize CI smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           echo "${{ github.workspace }}/sdk/iCUESDK/redist/x64" >> "$GITHUB_PATH"
 
       - name: Run smoke test
-        run: cargo test --test smoke
+        run: cargo test --test smoke -- --test-threads=1
 
   smoke-macos:
     name: Smoke Test (macOS)
@@ -101,4 +101,4 @@ jobs:
           echo "DYLD_FRAMEWORK_PATH=${{ github.workspace }}/sdk_framework" >> "$GITHUB_ENV"
 
       - name: Run smoke test
-        run: cargo test --test smoke
+        run: cargo test --test smoke -- --test-threads=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.1] - 2026-02-07
+
+### Fixed
+- Fix macOS SIGBUS on reconnect: session state callback now uses a process-wide static sender instead of a per-`Session` pinned pointer, preventing use-after-free when the SDK's background thread fires during teardown (#18).
+- Fix CI smoke test deadlocks by running tests with `--test-threads=1` since the iCUE SDK uses global state (#19).
+
 ## [v0.1.0] - 2026-02-07
 
 Complete rewrite for iCUE SDK v4 (backed by `cue-sdk-sys` 0.1.0).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cue-sdk"
 description = "A high-level safe wrapper for the Corsair iCUE SDK v4."
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Scott Meschke <scottmeschke@gmail.com>"]
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
## Summary
- **Fix #18**: Replace per-`Session` `Pin<Box<Sender>>` with a process-wide `static Mutex<Option<Sender>>` for session state callbacks. The trampoline now reads from the static instead of dereferencing a context pointer, so the SDK's background thread can never hit a freed pointer during teardown. `clear_session_sender()` is called before `CorsairDisconnect()` in `Drop`.
- **Fix #19**: Add `--test-threads=1` to CI smoke test commands on both Windows and macOS, since the iCUE SDK uses global state and concurrent tests deadlock.
- Bump version to v0.1.1.

## Test plan
- [x] `cargo check` passes
- [x] `cargo check --features async` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] CI smoke tests pass on Windows and macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)